### PR TITLE
ABSO-3143 enable to highligh word with diacritics when user misstyped them

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "gulp test"
   },
   "dependencies": {
+    "diacritics": "^1.3.0",
     "lodash": "^4.13.1"
   },
   "devDependencies": {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -41,4 +41,13 @@ describe('absolvent/highlightFoundText/index', () => {
     assert.ok(highlighted.isHighlighted);
     assert.strictEqual(highlighted.highlightedText, '[F] U[f]O ObO[oR]');
   });
+
+  it('highlights text with diacritics characters', () => {
+    // @TODO bug in Loadash.words (lóDż => ['ló', 'Dż'] insteadof ['lóDż'])
+    // const highlighted = highlightFoundText('lóDż', 'to jest Miasto łÓdź w Polsce', '[', ']');
+    const highlighted = highlightFoundText('lódż jest', 'to jest Miasto łÓDź w Polsce', '[', ']');
+
+    assert.ok(highlighted.isHighlighted);
+    assert.strictEqual(highlighted.highlightedText, 'to [jest] Miasto [łÓDź] w Polsce');
+  });
 });

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,5 +1,0 @@
-const highlightFoundText = require('./index');
-
-const highlighted = highlightFoundText('lódż', 'to jest Miasto łÓDź w Polsce', '[', ']');
-
-console.log(highlighted);

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,0 +1,5 @@
+const highlightFoundText = require('./index');
+
+const highlighted = highlightFoundText('lódż', 'to jest Miasto łÓDź w Polsce', '[', ']');
+
+console.log(highlighted);


### PR DESCRIPTION
w skrócie zaznacz `to [jest] Miasto [łÓDź] w Polsce` gdy użytkownik wprowadził `lódż jest`

1. na razie funkcjonalność ta jest zaszyta w bibliotece (działa zawsze). można by było dodać do funkcji `highlightFoundText` piąty parametr - ale to już będzie tochę za dużo ?
2. do rozpoznawania znaków akcentowych wykorzystywana jest biblioteka `diacritics` co oznacza że rozpoznawane są też niemieckie, francuskie itp a nie tylko polskie znaki
3. jest problem z `Loadash.words` dla frazy `lóDż` która jest rozpoznawana jak `['ló', 'Dż']` zamiast `['lóDż']`